### PR TITLE
[Feature] 비로그인 상태에서의 url 관리 기능

### DIFF
--- a/src/docs/asciidoc/api/auth/auth.adoc
+++ b/src/docs/asciidoc/api/auth/auth.adoc
@@ -35,4 +35,25 @@ include::{snippets}/auth-refresh/request-fields.adoc[]
 include::{snippets}/auth-refresh/http-response.adoc[]
 include::{snippets}/auth-refresh/response-fields.adoc[]
 
+[[Auth-cookie]]
+=== cookie
 
+==== HTTP Request
+include::{snippets}/auth-set-cookie/http-request.adoc[]
+include::{snippets}/auth-set-cookie/request-cookies.adoc[]
+
+==== HTTP Response
+include::{snippets}/auth-set-cookie/http-response.adoc[]
+include::{snippets}/auth-set-cookie/response-cookies.adoc[]
+
+
+[[Auth-cookie]]
+=== cookie-already-session-exist
+
+==== HTTP Request
+include::{snippets}/auth-set-cookie-already-session-exist/http-request.adoc[]
+include::{snippets}/auth-set-cookie-already-session-exist/request-cookies.adoc[]
+
+==== HTTP Response
+include::{snippets}/auth-set-cookie-already-session-exist/http-response.adoc[]
+include::{snippets}/auth-set-cookie-already-session-exist/response-fields.adoc[]

--- a/src/docs/asciidoc/api/url/url.adoc
+++ b/src/docs/asciidoc/api/url/url.adoc
@@ -1,28 +1,6 @@
 [[URL-API]]
 == URL API
 
-[[URL-Post]]
-=== URL Post
-
-==== HTTP Request
-include::{snippets}/url-post/http-request.adoc[]
-include::{snippets}/url-post/request-fields.adoc[]
-
-==== HTTP Response
-include::{snippets}/url-post/http-response.adoc[]
-include::{snippets}/url-post/response-fields.adoc[]
-
-[[URL-Post-logged-in]]
-=== URL Post - Logged in
-
-==== HTTP Request
-include::{snippets}/url-post-logged-in/http-request.adoc[]
-include::{snippets}/url-post-logged-in/request-fields.adoc[]
-
-==== HTTP Response
-include::{snippets}/url-post-logged-in/http-response.adoc[]
-include::{snippets}/url-post-logged-in/response-fields.adoc[]
-
 [[URL-redirect]]
 === URL redirect
 
@@ -34,88 +12,118 @@ include::{snippets}/url-redirect/path-parameters.adoc[]
 include::{snippets}/url-redirect/http-response.adoc[]
 include::{snippets}/url-redirect/response-headers.adoc[]
 
-
 [[URL-redirect-expired]]
 === URL redirect - 만료된 url 요청
 
 ==== HTTP Request
-include::{snippets}/url-redirect-expired/http-request.adoc[]
-include::{snippets}/url-redirect-expired/path-parameters.adoc[]
+include::{snippets}/url-redirect-with-expired/http-request.adoc[]
+include::{snippets}/url-redirect-with-expired/path-parameters.adoc[]
 
 ==== HTTP Response
-include::{snippets}/url-redirect-expired/http-response.adoc[]
-include::{snippets}/url-redirect-expired/response-fields.adoc[]
+include::{snippets}/url-redirect-with-expired/http-response.adoc[]
+include::{snippets}/url-redirect-with-expired/response-fields.adoc[]
 
-[[URL-Get-List]]
-=== URL GET - List
+
+[[URL-Post]]
+=== URL Post - 비로그인 상태
 
 ==== HTTP Request
-include::{snippets}/url-get/http-request.adoc[]
-include::{snippets}/url-get/query-parameters.adoc[]
+include::{snippets}/url-post/http-request.adoc[]
+include::{snippets}/url-post/request-fields.adoc[]
+
+==== HTTP Response
+include::{snippets}/url-post/http-response.adoc[]
+include::{snippets}/url-post/response-fields.adoc[]
+
+[[URL-Post-logged-in]]
+=== URL Post - 로그인 상태
+
+==== HTTP Request
+include::{snippets}/url-post-for-me/http-request.adoc[]
+include::{snippets}/url-post-for-me/request-headers.adoc[]
+include::{snippets}/url-post-for-me/request-fields.adoc[]
+
+==== HTTP Response
+include::{snippets}/url-post-for-me/http-response.adoc[]
+include::{snippets}/url-post-for-me/response-fields.adoc[]
+
+
+[[URL-Get-List]]
+=== URL Get List - 로그인 상태
+
+==== HTTP Request
+include::{snippets}/url-get-for-me/http-request.adoc[]
+include::{snippets}/url-get-for-me/request-headers.adoc[]
+include::{snippets}/url-get-for-me/query-parameters.adoc[]
 
 
 ==== HTTP Response
-include::{snippets}/url-get/http-response.adoc[]
-include::{snippets}/url-get/response-fields.adoc[]
+include::{snippets}/url-get-for-me/http-response.adoc[]
+include::{snippets}/url-get-for-me/response-fields.adoc[]
 
 
 [[URL-put]]
-=== URL PUT
+=== URL Put - 로그인 상태
 
 ==== HTTP Request
-include::{snippets}/url-put/http-request.adoc[]
-include::{snippets}/url-put/path-parameters.adoc[]
+include::{snippets}/url-put-for-me/http-request.adoc[]
+include::{snippets}/url-put-for-me/request-headers.adoc[]
+include::{snippets}/url-put-for-me/path-parameters.adoc[]
 
 
 ==== HTTP Response
-include::{snippets}/url-put/http-response.adoc[]
+include::{snippets}/url-put-for-me/http-response.adoc[]
 
 [[URL-put-with-invalid-expired-at]]
-=== URL PUT - 유효하지않은 만료날짜
+=== URL Put - 로그인 상태 - 유효하지 않은 만료기간
 
 ==== HTTP Request
-include::{snippets}/url-put-with-invalid-expired-at/http-request.adoc[]
-include::{snippets}/url-put-with-invalid-expired-at/path-parameters.adoc[]
+include::{snippets}/url-put-for-me-with-invalid-expired-at/http-request.adoc[]
+include::{snippets}/url-put-for-me-with-invalid-expired-at/request-headers.adoc[]
+include::{snippets}/url-put-for-me-with-invalid-expired-at/path-parameters.adoc[]
 
 
 ==== HTTP Response
-include::{snippets}/url-put-with-invalid-expired-at/http-response.adoc[]
-include::{snippets}/url-put-with-invalid-expired-at/response-fields.adoc[]
+include::{snippets}/url-put-for-me-with-invalid-expired-at/http-response.adoc[]
+include::{snippets}/url-put-for-me-with-invalid-expired-at/response-fields.adoc[]
 
 
 [[URL-put-with-invalid-member]]
-=== URL PUT - 유효하지않은 소유권
+=== URL PUT - 로그인 상태 - 유효하지않은 소유권
 
 ==== HTTP Request
-include::{snippets}/url-put-with-invalid-member/http-request.adoc[]
-include::{snippets}/url-put-with-invalid-member/path-parameters.adoc[]
+include::{snippets}/url-put-for-me-with-invalid-member/http-request.adoc[]
+include::{snippets}/url-put-for-me-with-invalid-member/request-headers.adoc[]
+include::{snippets}/url-put-for-me-with-invalid-member/path-parameters.adoc[]
 
 
 ==== HTTP Response
-include::{snippets}/url-put-with-invalid-member/http-response.adoc[]
-include::{snippets}/url-put-with-invalid-member/response-fields.adoc[]
-
-[[URL-expire]]
-=== URL Expire
-
-==== HTTP Request
-include::{snippets}/url-expire/http-request.adoc[]
-include::{snippets}/url-expire/path-parameters.adoc[]
-include::{snippets}/url-expire/request-fields.adoc[]
-
-
-==== HTTP Response
-include::{snippets}/url-expire/http-response.adoc[]
-include::{snippets}/url-expire/response-fields.adoc[]
+include::{snippets}/url-put-for-me-with-invalid-member/http-response.adoc[]
+include::{snippets}/url-put-for-me-with-invalid-member/response-fields.adoc[]
 
 [[URL-delete]]
-=== URL Delete
+=== URL Delete - 로그인 상태
 
 ==== HTTP Request
-include::{snippets}/url-delete/http-request.adoc[]
-include::{snippets}/url-delete/path-parameters.adoc[]
-include::{snippets}/url-delete/request-fields.adoc[]
+include::{snippets}/url-delete-for-me/http-request.adoc[]
+include::{snippets}/url-delete-for-me/request-headers.adoc[]
+include::{snippets}/url-delete-for-me/path-parameters.adoc[]
+include::{snippets}/url-delete-for-me/request-fields.adoc[]
 
 
 ==== HTTP Response
-include::{snippets}/url-delete/http-response.adoc[]
+include::{snippets}/url-delete-for-me/http-response.adoc[]
+
+[[URL-expire]]
+=== URL Expire - 로그인 상태
+
+==== HTTP Request
+include::{snippets}/url-expire-for-me/http-request.adoc[]
+include::{snippets}/url-expire-for-me/request-headers.adoc[]
+include::{snippets}/url-expire-for-me/path-parameters.adoc[]
+include::{snippets}/url-expire-for-me/request-fields.adoc[]
+
+
+==== HTTP Response
+include::{snippets}/url-expire-for-me/http-response.adoc[]
+

--- a/src/docs/asciidoc/api/url/url.adoc
+++ b/src/docs/asciidoc/api/url/url.adoc
@@ -35,6 +35,17 @@ include::{snippets}/url-post/request-fields.adoc[]
 include::{snippets}/url-post/http-response.adoc[]
 include::{snippets}/url-post/response-fields.adoc[]
 
+[[URL-Get-List]]
+=== URL Get List - 비로그인 상태
+
+==== HTTP Request
+include::{snippets}/url-get/http-request.adoc[]
+include::{snippets}/url-get/query-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/url-get/http-response.adoc[]
+include::{snippets}/url-get/response-fields.adoc[]
+
 [[URL-Post-logged-in]]
 === URL Post - 로그인 상태
 

--- a/src/main/java/com/example/urlshortener/domain/auth/api/AuthController.java
+++ b/src/main/java/com/example/urlshortener/domain/auth/api/AuthController.java
@@ -3,8 +3,11 @@ package com.example.urlshortener.domain.auth.api;
 import com.example.urlshortener.domain.auth.application.AuthService;
 import com.example.urlshortener.domain.auth.dto.*;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
@@ -26,6 +29,14 @@ public class AuthController {
     public ResponseEntity<RefreshAuthResponse> refreshAuth(@RequestBody final RefreshAuthRequest refreshTokenReq) {
         RefreshAuthResponse refreshAuthResponse = authService.refreshAuth(refreshTokenReq);
         return ResponseEntity.ok().body(refreshAuthResponse);
+    }
+
+    @GetMapping("/set-cookie")
+    public ResponseEntity<Void> cookie(@CookieValue(value = "sessionId", required = false) String sessionId) {
+        SessionDto sessionDto = authService.makeSession(sessionId, UUID.randomUUID().toString());
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, sessionDto.toCookie().toString())
+                .build();
     }
 
 }

--- a/src/main/java/com/example/urlshortener/domain/auth/config/AuthenticationConfig.java
+++ b/src/main/java/com/example/urlshortener/domain/auth/config/AuthenticationConfig.java
@@ -23,6 +23,7 @@ public class AuthenticationConfig implements WebMvcConfigurer {
                 "/api/members/signup",
                 "/api/auth/oauth",
                 "/api/auth/signin",
+                "/api/auth/set-cookie",
                 "/docs/index.html",
                 "/favicon.ico",
                 "/api/url",

--- a/src/main/java/com/example/urlshortener/domain/auth/dao/SessionRepository.java
+++ b/src/main/java/com/example/urlshortener/domain/auth/dao/SessionRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 
 public interface SessionRepository extends JpaRepository<Session, Long> {
     boolean existsByUuid(String uuid);
+    Optional<Session> findByUuid(String uuid);
 }

--- a/src/main/java/com/example/urlshortener/domain/auth/dao/SessionRepository.java
+++ b/src/main/java/com/example/urlshortener/domain/auth/dao/SessionRepository.java
@@ -1,0 +1,10 @@
+package com.example.urlshortener.domain.auth.dao;
+
+import com.example.urlshortener.domain.auth.domain.Session;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface SessionRepository extends JpaRepository<Session, Long> {
+    boolean existsByUuid(String uuid);
+}

--- a/src/main/java/com/example/urlshortener/domain/auth/domain/Session.java
+++ b/src/main/java/com/example/urlshortener/domain/auth/domain/Session.java
@@ -1,0 +1,22 @@
+package com.example.urlshortener.domain.auth.domain;
+
+import jakarta.persistence.*;
+
+@Entity
+public class Session {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+
+    @Column(name = "uuid", unique = true)
+    private String uuid;
+
+    public String getUUID() {
+        return uuid;
+    }
+
+    public void assignUUID(String uuid) {
+        this.uuid = uuid;
+    }
+}

--- a/src/main/java/com/example/urlshortener/domain/auth/dto/SessionDto.java
+++ b/src/main/java/com/example/urlshortener/domain/auth/dto/SessionDto.java
@@ -1,0 +1,32 @@
+package com.example.urlshortener.domain.auth.dto;
+
+import com.example.urlshortener.domain.auth.domain.Session;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.http.ResponseCookie;
+
+@Data
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SessionDto {
+
+    private String uuid;
+
+    @Builder
+    private SessionDto(String uuid) {
+        this.uuid = uuid;
+    }
+
+    public static SessionDto of(Session session) {
+        return SessionDto.builder().uuid(session.getUUID()).build();
+    }
+
+    public ResponseCookie toCookie(){
+        return ResponseCookie.from("sessionId", this.uuid)
+                .httpOnly(true)
+                .secure(true)
+                .maxAge(86400 * 7)
+                .build();
+    }
+}

--- a/src/main/java/com/example/urlshortener/domain/auth/exception/AlreadySessionExist.java
+++ b/src/main/java/com/example/urlshortener/domain/auth/exception/AlreadySessionExist.java
@@ -1,0 +1,10 @@
+package com.example.urlshortener.domain.auth.exception;
+
+import com.example.urlshortener.global.error.ErrorCode;
+import com.example.urlshortener.global.error.exception.BusinessException;
+
+public class AlreadySessionExist extends BusinessException {
+    public AlreadySessionExist(){
+        super(ErrorCode.ALREADY_SESSION_EXIST);
+    }
+}

--- a/src/main/java/com/example/urlshortener/domain/auth/exception/DuplicatedSessionUUID.java
+++ b/src/main/java/com/example/urlshortener/domain/auth/exception/DuplicatedSessionUUID.java
@@ -1,0 +1,13 @@
+package com.example.urlshortener.domain.auth.exception;
+
+import com.example.urlshortener.global.error.ErrorCode;
+import com.example.urlshortener.global.error.exception.BusinessException;
+
+public class DuplicatedSessionUUID extends BusinessException {
+
+    public DuplicatedSessionUUID(){
+        super(ErrorCode.DUPLICATED_SESSION_UUID);
+    }
+
+
+}

--- a/src/main/java/com/example/urlshortener/domain/auth/exception/SessionNotFoundException.java
+++ b/src/main/java/com/example/urlshortener/domain/auth/exception/SessionNotFoundException.java
@@ -1,0 +1,10 @@
+package com.example.urlshortener.domain.auth.exception;
+
+import com.example.urlshortener.global.error.ErrorCode;
+import com.example.urlshortener.global.error.exception.BusinessException;
+
+public class SessionNotFoundException extends BusinessException {
+    public SessionNotFoundException(){
+        super("존재하지 않는 세션 ID 입니다.",ErrorCode.ENTITY_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/example/urlshortener/domain/url/api/UrlController.java
+++ b/src/main/java/com/example/urlshortener/domain/url/api/UrlController.java
@@ -19,7 +19,7 @@ public class UrlController {
         return ResponseEntity.status(HttpStatus.CREATED).body(urlService.shortenUrl(shortenUrlRequest));
     }
 
-    @GetMapping("/api/url")
+    @GetMapping("/api/me/url")
     public ResponseEntity<ShortenUrlsResponse> findShortenUrl(@RequestParam Long memberId) {
         return ResponseEntity.ok(urlService.findAllByMemberId(memberId));
     }

--- a/src/main/java/com/example/urlshortener/domain/url/api/UrlController.java
+++ b/src/main/java/com/example/urlshortener/domain/url/api/UrlController.java
@@ -19,8 +19,13 @@ public class UrlController {
         return ResponseEntity.status(HttpStatus.CREATED).body(urlService.shortenUrl(shortenUrlRequest));
     }
 
+    @GetMapping("/api/url")
+    public ResponseEntity<ShortenUrlsResponse> findShorten(@RequestParam String sessionUuid) {
+        return ResponseEntity.ok(urlService.findAllBySessionUuid(sessionUuid));
+    }
+
     @GetMapping("/api/me/url")
-    public ResponseEntity<ShortenUrlsResponse> findShortenUrl(@RequestParam Long memberId) {
+    public ResponseEntity<ShortenUrlsResponse> findShortenUrlForMe(@RequestParam Long memberId) {
         return ResponseEntity.ok(urlService.findAllByMemberId(memberId));
     }
 

--- a/src/main/java/com/example/urlshortener/domain/url/application/UrlService.java
+++ b/src/main/java/com/example/urlshortener/domain/url/application/UrlService.java
@@ -27,9 +27,16 @@ public class UrlService {
     public ShortenUrlResponse shortenUrl(ShortenUrlRequest shortenUrlRequest) {
         String fullUrl = shortenUrlRequest.getFullUrl();
         String hash = UrlShortener.shortenUrl(fullUrl);
+        String sessionUuid = shortenUrlRequest.getSessionUuid();
 
-        Url url = urlRepository.save(Url.of(fullUrl, hash));
+        Url url = Url.of(fullUrl, hash);
 
+        Session session = sessionRepository.findByUuid(sessionUuid)
+                .orElseThrow(() -> new SessionNotFoundException());
+
+        url.assignSession(session);
+
+        urlRepository.save(url);
         return ShortenUrlResponse.of(url);
     }
 

--- a/src/main/java/com/example/urlshortener/domain/url/application/UrlService.java
+++ b/src/main/java/com/example/urlshortener/domain/url/application/UrlService.java
@@ -1,5 +1,8 @@
 package com.example.urlshortener.domain.url.application;
 
+import com.example.urlshortener.domain.auth.dao.SessionRepository;
+import com.example.urlshortener.domain.auth.domain.Session;
+import com.example.urlshortener.domain.auth.exception.SessionNotFoundException;
 import com.example.urlshortener.domain.member.dao.MemberRepository;
 import com.example.urlshortener.domain.member.domain.Member;
 import com.example.urlshortener.domain.url.dao.UrlRepository;
@@ -24,6 +27,9 @@ public class UrlService {
     private final UrlRepository urlRepository;
     private final MemberRepository memberRepository;
 
+    private final SessionRepository sessionRepository;
+
+    @Transactional
     public ShortenUrlResponse shortenUrl(ShortenUrlRequest shortenUrlRequest) {
         String fullUrl = shortenUrlRequest.getFullUrl();
         String hash = UrlShortener.shortenUrl(fullUrl);
@@ -40,6 +46,7 @@ public class UrlService {
         return ShortenUrlResponse.of(url);
     }
 
+    @Transactional
     public ShortenUrlResponse shortenUrlForMe(ShortenUrlForMeRequest shortenUrlForMeRequest) {
         String fullUrl = shortenUrlForMeRequest.getFullUrl();
         String hash = UrlShortener.shortenUrl(fullUrl);
@@ -68,7 +75,6 @@ public class UrlService {
     }
 
     public ShortenUrlsResponse findAllByMemberId(Long memberId) {
-        List<Url> all = urlRepository.findAll();
         List<Url> allByMemberId = urlRepository.findAllByMemberId(memberId);
         return ShortenUrlsResponse.of(allByMemberId);
     }
@@ -105,5 +111,10 @@ public class UrlService {
             throw new UrlNotMatchedByMember();
         }
         urlRepository.delete(url);
+    }
+
+    public ShortenUrlsResponse findAllBySessionUuid(String sessionUuid) {
+        List<Url> allByMemberId = urlRepository.findAllBySessionUuid(sessionUuid);
+        return ShortenUrlsResponse.of(allByMemberId);
     }
 }

--- a/src/main/java/com/example/urlshortener/domain/url/dao/UrlRepository.java
+++ b/src/main/java/com/example/urlshortener/domain/url/dao/UrlRepository.java
@@ -9,4 +9,5 @@ import java.util.Optional;
 public interface UrlRepository extends JpaRepository<Url, Long> {
     Optional<Url> findByHash(String hash);
     List<Url> findAllByMemberId(Long memberId);
+    List<Url> findAllBySessionUuid(String SessionUuid);
 }

--- a/src/main/java/com/example/urlshortener/domain/url/domain/Url.java
+++ b/src/main/java/com/example/urlshortener/domain/url/domain/Url.java
@@ -68,6 +68,10 @@ public class Url extends BaseTimeEntity {
         return member;
     }
 
+    public Session getSession() {
+        return session;
+    }
+
     public boolean checkExpired(LocalDateTime now) {
         if (now.isAfter(expiredAt)) {
             return true;

--- a/src/main/java/com/example/urlshortener/domain/url/domain/Url.java
+++ b/src/main/java/com/example/urlshortener/domain/url/domain/Url.java
@@ -1,5 +1,6 @@
 package com.example.urlshortener.domain.url.domain;
 
+import com.example.urlshortener.domain.auth.domain.Session;
 import com.example.urlshortener.domain.member.domain.Member;
 import com.example.urlshortener.domain.url.exception.InvalidProlongExpirationPeriodException;
 import com.example.urlshortener.global.common.domain.BaseTimeEntity;
@@ -29,8 +30,9 @@ public class Url extends BaseTimeEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @Column(name = "cookie_id")
-    private String cookieId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "session_id")
+    private Session session;
 
     @Column(name = "expired_at")
     private LocalDateTime expiredAt;
@@ -86,5 +88,9 @@ public class Url extends BaseTimeEntity {
 
     public void expire(LocalDateTime now) {
         this.expiredAt = now;
+    }
+
+    public void assignSession(Session session) {
+        this.session = session;
     }
 }

--- a/src/main/java/com/example/urlshortener/domain/url/dto/ShortenUrlRequest.java
+++ b/src/main/java/com/example/urlshortener/domain/url/dto/ShortenUrlRequest.java
@@ -1,5 +1,7 @@
 package com.example.urlshortener.domain.url.dto;
 
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotBlank;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Data;
@@ -9,11 +11,15 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ShortenUrlRequest {
 
+    @NotBlank
     private String fullUrl;
 
-    @Builder
-    private ShortenUrlRequest(String fullUrl) {
-        this.fullUrl = fullUrl;
-    }
+    @Nullable
+    private String sessionUuid;
 
+    @Builder
+    private ShortenUrlRequest(String fullUrl, String sessionUuid) {
+        this.fullUrl = fullUrl;
+        this.sessionUuid = sessionUuid;
+    }
 }

--- a/src/main/java/com/example/urlshortener/global/error/ErrorCode.java
+++ b/src/main/java/com/example/urlshortener/global/error/ErrorCode.java
@@ -26,6 +26,10 @@ public enum ErrorCode {
     EXPIRED_TOKEN(400,"O004","만료된 token 입니다."),
     FETCH_ACCESS_TOKEN(500, "O005","oauth login에 실패했습니다."),
 
+    // Auth
+    ALREADY_SESSION_EXIST(400, "A001", "이미 세션이 존재합니다."),
+    DUPLICATED_SESSION_UUID(500, "A002", "이미 존재하는 UUID가 할당되어 세션생성에 실패했습니다." ),
+
     // URL
     INVALID_HASH(400, "U001", "hash 값에 대응 되는 URL이 존재하지 않습니다."),
     EXPIRED_URL(400, "U002", "해당 url은 만료된 url입니다."),

--- a/src/test/java/com/example/urlshortener/domain/auth/api/AuthAcceptanceTest.java
+++ b/src/test/java/com/example/urlshortener/domain/auth/api/AuthAcceptanceTest.java
@@ -2,7 +2,11 @@ package com.example.urlshortener.domain.auth.api;
 
 import com.example.urlshortener.domain.auth.application.OauthHandler;
 import com.example.urlshortener.domain.auth.dao.RefreshTokenRepository;
-import com.example.urlshortener.domain.auth.dto.*;
+import com.example.urlshortener.domain.auth.dao.SessionRepository;
+import com.example.urlshortener.domain.auth.dto.BasicLoginResponse;
+import com.example.urlshortener.domain.auth.dto.OauthUserInformation;
+import com.example.urlshortener.domain.auth.dto.RefreshAuthRequest;
+import com.example.urlshortener.domain.auth.dto.SignInReq;
 import com.example.urlshortener.domain.member.dao.MemberRepository;
 import com.example.urlshortener.domain.member.domain.Member;
 import com.example.urlshortener.domain.member.domain.MemberBuilder;
@@ -31,12 +35,16 @@ public class AuthAcceptanceTest extends AcceptanceTest {
     @Autowired
     private MemberRepository memberRepository;
 
+    @Autowired
+    private SessionRepository sessionRepository;
+
     @Override
     @BeforeEach
     public void setUp() {
         super.setUp();
         refreshTokenRepository.deleteAll();
         memberRepository.deleteAllInBatch();
+        sessionRepository.deleteAllInBatch();
     }
 
     @MockBean
@@ -121,6 +129,44 @@ public class AuthAcceptanceTest extends AcceptanceTest {
 
         // then
         assertThat(extract.statusCode()).isEqualTo(HttpStatus.OK.value());
+
+    }
+
+    @Test
+    @DisplayName("Cookie API")
+    void cookie() {
+        // given
+
+        // when
+        ExtractableResponse<Response> extract =
+                given().log().all()
+                        .when()
+                        .get("/api/auth/set-cookie")
+                        .then().log().all()
+                        .extract();
+
+        // then
+        assertThat(extract.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(extract.cookie("sessionId")).isNotBlank();
+
+    }
+
+    @Test
+    @DisplayName("Cookie API - With Already Session Exist")
+    void cookieWithAlreadySessionExist() {
+        // given
+
+        // when
+        ExtractableResponse<Response> extract =
+                given().log().all()
+                        .when()
+                        .cookie("sessionId","uuid")
+                        .get("/api/auth/set-cookie")
+                        .then().log().all()
+                        .extract();
+
+        // then
+        assertThat(extract.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
 
     }
 

--- a/src/test/java/com/example/urlshortener/domain/auth/domain/SessionTest.java
+++ b/src/test/java/com/example/urlshortener/domain/auth/domain/SessionTest.java
@@ -1,0 +1,23 @@
+package com.example.urlshortener.domain.auth.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class SessionTest {
+
+    @Test
+    @DisplayName("session에 uuid를 지정한다.")
+    void assignUUID() {
+        // given
+        Session session = new Session();
+
+        // when
+        session.assignUUID("UUID");
+
+        // then
+        assertThat(session.getUUID()).isEqualTo("UUID");
+    }
+}

--- a/src/test/java/com/example/urlshortener/domain/member/dao/MemberRepositoryTest.java
+++ b/src/test/java/com/example/urlshortener/domain/member/dao/MemberRepositoryTest.java
@@ -22,9 +22,9 @@ class MemberRepositoryTest extends RepositoryTest {
 
     @BeforeEach
     public void setUp() throws Exception {
-        final String email = "solver@test.com";
+        final String email = "test@test.com";
         this.email = email;
-        final String password = "solver";
+        final String password = "test";
         Member build = Member.builder().email(email).password(password).build();
         saveMember = memberRepository.save(build);
     }

--- a/src/test/java/com/example/urlshortener/domain/url/api/UrlAcceptanceTest.java
+++ b/src/test/java/com/example/urlshortener/domain/url/api/UrlAcceptanceTest.java
@@ -1,6 +1,7 @@
 package com.example.urlshortener.domain.url.api;
 
 import com.example.urlshortener.domain.auth.dao.RefreshTokenRepository;
+import com.example.urlshortener.domain.auth.dao.SessionRepository;
 import com.example.urlshortener.domain.auth.dto.BasicLoginResponse;
 import com.example.urlshortener.domain.auth.dto.SignInReq;
 import com.example.urlshortener.domain.member.dao.MemberRepository;
@@ -78,6 +79,41 @@ public class UrlAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
+    @DisplayName("URL Shorten Url GET API - LIST - 비로그인 상태")
+    void getList() throws Exception {
+        // given
+        String sessionUuid = getSessionUuid();
+        ShortenUrlRequest request = ShortenUrlRequest.builder()
+                .fullUrl("www.test.com")
+                .sessionUuid(sessionUuid)
+                .build();
+
+        // when
+        given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(request)
+                .when()
+                .post("/api/url")
+                .then().log().all();
+
+
+        // when
+        ExtractableResponse<Response> extract = given().log().all()
+                .when()
+                .queryParam("sessionUuid", sessionUuid)
+                .get("/api/url")
+                .then().log().all()
+                .extract();
+
+        ShortenUrlsResponse body = extract.body().as(ShortenUrlsResponse.class);
+        List<ShortenUrlResponse> urls = body.getUrls();
+
+        // then
+        assertThat(extract.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(urls.size()).isNotZero();
+    }
+
+    @Test
     @DisplayName("URL Shorten Post API - 로그인 상태")
     void shortenUrlForMe() {
 
@@ -145,8 +181,8 @@ public class UrlAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
-    @DisplayName("URL Shorten Url GET API - LIST")
-    void getList() throws Exception {
+    @DisplayName("URL Shorten Url GET API - LIST - 로그인 상태")
+    void getListForMe() throws Exception {
         // given
         requestSignup();
         BasicLoginResponse basicLoginResponse = requestSignin();

--- a/src/test/java/com/example/urlshortener/domain/url/api/UrlAcceptanceTest.java
+++ b/src/test/java/com/example/urlshortener/domain/url/api/UrlAcceptanceTest.java
@@ -35,6 +35,8 @@ public class UrlAcceptanceTest extends AcceptanceTest {
     private RefreshTokenRepository refreshTokenRepository;
     @Autowired
     private MemberRepository memberRepository;
+    @Autowired
+    private SessionRepository sessionRepository;
 
 
     @Override
@@ -44,14 +46,17 @@ public class UrlAcceptanceTest extends AcceptanceTest {
         urlRepository.deleteAllInBatch();
         refreshTokenRepository.deleteAll();
         memberRepository.deleteAllInBatch();
+        sessionRepository.deleteAllInBatch();
     }
 
     @Test
     @DisplayName("URL Shorten Post API - 비로그인 상태")
     void shortenUrl() {
         // given
+        String sessionUuid = getSessionUuid();
         ShortenUrlRequest request = ShortenUrlRequest.builder()
                 .fullUrl("www.test.com")
+                .sessionUuid(sessionUuid)
                 .build();
 
         // when
@@ -109,8 +114,10 @@ public class UrlAcceptanceTest extends AcceptanceTest {
     @DisplayName("URL Shorten Url redirect API")
     void redirect() throws Exception {
         // given
+        String sessionUuid = getSessionUuid();
         ShortenUrlRequest request = ShortenUrlRequest.builder()
                 .fullUrl("http://localhost:" + RestAssured.port + "/actuator/health")
+                .sessionUuid(sessionUuid)
                 .build();
 
         ExtractableResponse<Response> expected = given().log().all()
@@ -320,5 +327,14 @@ public class UrlAcceptanceTest extends AcceptanceTest {
                         .extract();
 
         return extract.body().as(ShortenUrlResponse.class);
+    }
+
+    private String getSessionUuid(){
+        return given().log().all()
+                        .when()
+                        .get("/api/auth/set-cookie")
+                        .then().log().all()
+                        .extract()
+                        .cookie("sessionId");
     }
 }

--- a/src/test/java/com/example/urlshortener/domain/url/api/UrlAcceptanceTest.java
+++ b/src/test/java/com/example/urlshortener/domain/url/api/UrlAcceptanceTest.java
@@ -161,9 +161,10 @@ public class UrlAcceptanceTest extends AcceptanceTest {
 
         // when
         ExtractableResponse<Response> extract = given().log().all()
+                .header("authorization", "Bearer " + basicLoginResponse.getAccessToken())
                 .when()
                 .queryParam("memberId", memberId)
-                .get("/api/url")
+                .get("/api/me/url")
                 .then().log().all()
                 .extract();
 

--- a/src/test/java/com/example/urlshortener/domain/url/api/UrlControllerTest.java
+++ b/src/test/java/com/example/urlshortener/domain/url/api/UrlControllerTest.java
@@ -202,7 +202,7 @@ class UrlControllerTest extends ControllerTest {
         given(urlService.findAllByMemberId(1L)).willReturn(expected);
 
         // when
-        ResultActions resultActions = mockMvc.perform(get("/api/url")
+        ResultActions resultActions = mockMvc.perform(get("/api/me/url")
                         .param("memberId", "1")
                         .header("authorization", "Bearer TOKEN")
                 )

--- a/src/test/java/com/example/urlshortener/domain/url/api/UrlControllerTest.java
+++ b/src/test/java/com/example/urlshortener/domain/url/api/UrlControllerTest.java
@@ -81,6 +81,54 @@ class UrlControllerTest extends ControllerTest {
     }
 
     @Test
+    @DisplayName("비로그인 상태에서 short url을 조회하는 요청을 처리한다.")
+    void findShortenUrl() throws Exception {
+        // given
+
+        ShortenUrlResponse shortUrl_1 = ShortenUrlResponse.builder()
+                .fullUrl("www.test.com")
+                .hash("hash")
+                .build();
+
+        ShortenUrlResponse shortUrl_2 = ShortenUrlResponse.builder()
+                .fullUrl("www.test2.com")
+                .hash("hash2")
+                .build();
+
+        ShortenUrlsResponse expected = ShortenUrlsResponse.builder()
+                .urls(List.of(shortUrl_1, shortUrl_2))
+                .build();
+
+        given(urlService.findAllBySessionUuid("sessionUuid")).willReturn(expected);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(get("/api/url")
+                        .param("sessionUuid", "sessionUuid")
+                )
+                .andDo(print())
+                .andDo(document("url-get",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        queryParameters(
+                                parameterWithName("sessionUuid").description("session UUID")
+                        ),
+                        responseFields(
+                                fieldWithPath("urls").type(JsonFieldType.ARRAY)
+                                        .description("url list")
+                                ,
+                                fieldWithPath("urls.[].fullUrl").type(JsonFieldType.STRING)
+                                        .description("full URL"),
+                                fieldWithPath("urls.[].hash").type(JsonFieldType.STRING)
+                                        .description("hash result for shorten")
+                        )
+                ));
+
+        // then
+        resultActions.andExpect(status().isOk());
+    }
+
+
+    @Test
     @DisplayName("로그인이 된 상태에서의 URL Shorten 요청을 처리한다.")
     void shortenUrlForMe() throws Exception {
         // given
@@ -186,7 +234,7 @@ class UrlControllerTest extends ControllerTest {
 
     @Test
     @DisplayName("로그인이 된 상태에서 short url을 조회하는 요청을 처리한다.")
-    void findShortenUrl() throws Exception {
+    void findShortenUrlForMe() throws Exception {
         // given
 
         ShortenUrlResponse shortUrl_1 = ShortenUrlResponse.builder()

--- a/src/test/java/com/example/urlshortener/domain/url/api/UrlControllerTest.java
+++ b/src/test/java/com/example/urlshortener/domain/url/api/UrlControllerTest.java
@@ -20,8 +20,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.mockito.BDDMockito.*;
-import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
-import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
+import static org.springframework.restdocs.headers.HeaderDocumentation.*;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
@@ -101,9 +100,11 @@ class UrlControllerTest extends ControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andDo(print())
-                .andDo(document("url-post-logged-in",
+                .andDo(document("url-post-for-me",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
+                        requestHeaders(
+                                headerWithName("authorization").description("accessToken")),
                         requestFields(
                                 fieldWithPath("memberId").type(JsonFieldType.NUMBER)
                                         .description("memberId").optional(),
@@ -159,7 +160,7 @@ class UrlControllerTest extends ControllerTest {
         // when
         ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders.get("/{hash}", "hash"))
                 .andDo(print())
-                .andDo(document("url-redirect-expired",
+                .andDo(document("url-redirect-with-expired",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         pathParameters(
@@ -207,9 +208,11 @@ class UrlControllerTest extends ControllerTest {
                         .header("authorization", "Bearer TOKEN")
                 )
                 .andDo(print())
-                .andDo(document("url-get",
+                .andDo(document("url-get-for-me",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
+                        requestHeaders(
+                                headerWithName("authorization").description("accessToken")),
                         queryParameters(
                                 parameterWithName("memberId").description("member ID")
                         ),
@@ -247,9 +250,11 @@ class UrlControllerTest extends ControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andDo(print())
-                .andDo(document("url-put",
+                .andDo(document("url-put-for-me",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
+                        requestHeaders(
+                                headerWithName("authorization").description("accessToken")),
                         pathParameters(
                                 parameterWithName("hash").description("hash value of full url")
                         ),
@@ -288,9 +293,11 @@ class UrlControllerTest extends ControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andDo(print())
-                .andDo(document("url-put-with-invalid-expired-at",
+                .andDo(document("url-put-for-me-with-invalid-expired-at",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
+                        requestHeaders(
+                                headerWithName("authorization").description("accessToken")),
                         pathParameters(
                                 parameterWithName("hash").description("hash value of full url")
                         ),
@@ -337,9 +344,11 @@ class UrlControllerTest extends ControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andDo(print())
-                .andDo(document("url-put-with-invalid-member",
+                .andDo(document("url-put-for-me-with-invalid-member",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
+                        requestHeaders(
+                                headerWithName("authorization").description("accessToken")),
                         pathParameters(
                                 parameterWithName("hash").description("hash value of full url")
                         ),
@@ -363,6 +372,45 @@ class UrlControllerTest extends ControllerTest {
         resultActions.andExpect(status().isBadRequest());
 
     }
+
+    @Test
+    @DisplayName("로그인된 상태에서 만료된 url을 삭제하는 요청을 처리한다.")
+    void expire() throws Exception {
+        // given
+        ShortenUrlUpdateRequest request = ShortenUrlUpdateRequest.builder()
+                .memberId(1L)
+                .build();
+
+        willDoNothing().given(urlService).expire("hash", request);
+
+
+        // when
+        ResultActions resultActions = mockMvc.perform(post("/api/me/url/{hash}/expire", "hash")
+                        .header("authorization", "Bearer TOKEN")
+                        .characterEncoding("utf-8")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andDo(document("url-expire-for-me",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(
+                                headerWithName("authorization").description("accessToken")),
+                        pathParameters(
+                                parameterWithName("hash").description("hash value of full url")
+                        ),
+                        requestFields(
+                                fieldWithPath("memberId").type(JsonFieldType.NUMBER)
+                                        .description("memberId"),
+                                fieldWithPath("expireAt").type(JsonFieldType.STRING)
+                                        .description("prolong period").ignored()
+                        )
+                ));
+
+        // then
+        resultActions.andExpect(status().isOk());
+
+    }
     @Test
     @DisplayName("hash값에 해당하는 url을 삭제한다.")
     void deleteUrl() throws Exception {
@@ -380,9 +428,11 @@ class UrlControllerTest extends ControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andDo(print())
-                .andDo(document("url-delete",
+                .andDo(document("url-delete-for-me",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
+                        requestHeaders(
+                                headerWithName("authorization").description("accessToken")),
                         pathParameters(
                                 parameterWithName("hash").description("hash value of full url")
                         ),

--- a/src/test/java/com/example/urlshortener/domain/url/api/UrlControllerTest.java
+++ b/src/test/java/com/example/urlshortener/domain/url/api/UrlControllerTest.java
@@ -42,6 +42,7 @@ class UrlControllerTest extends ControllerTest {
         // given
         ShortenUrlRequest request = ShortenUrlRequest.builder()
                 .fullUrl("www.test.com")
+                .sessionUuid("uuid")
                 .build();
 
         ShortenUrlResponse expected = ShortenUrlResponse.builder()
@@ -62,7 +63,9 @@ class UrlControllerTest extends ControllerTest {
                         preprocessResponse(prettyPrint()),
                         requestFields(
                                 fieldWithPath("fullUrl").type(JsonFieldType.STRING)
-                                        .description("full URL")
+                                        .description("full URL"),
+                                fieldWithPath("sessionUuid").type(JsonFieldType.STRING)
+                                        .description("session UUID")
                         ),
                         responseFields(
                                 fieldWithPath("fullUrl").type(JsonFieldType.STRING)

--- a/src/test/java/com/example/urlshortener/domain/url/application/UrlServiceTest.java
+++ b/src/test/java/com/example/urlshortener/domain/url/application/UrlServiceTest.java
@@ -1,5 +1,7 @@
 package com.example.urlshortener.domain.url.application;
 
+import com.example.urlshortener.domain.auth.dao.SessionRepository;
+import com.example.urlshortener.domain.auth.domain.Session;
 import com.example.urlshortener.domain.member.dao.MemberRepository;
 import com.example.urlshortener.domain.member.domain.Member;
 import com.example.urlshortener.domain.url.dao.UrlRepository;
@@ -16,6 +18,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.LocalDateTime;
 import java.util.NoSuchElementException;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -242,5 +245,30 @@ class UrlServiceTest extends IntegrationTest {
         assertThatThrownBy(()->urlRepository.findByHash(hash).orElseThrow()).isInstanceOf(NoSuchElementException.class);
     }
 
+    @Test
+    @DisplayName("sessionUuid로 url을 조죄한다.")
+    void findAllBySessionUuid(){
+        // given
+        Session session = new Session();
+        String uuid = UUID.randomUUID().toString();
+        session.assignUUID(uuid);
+        sessionRepository.save(session);
+
+        String url = "www.test.com";
+        Url savedUrl = Url.builder()
+                .fullUrl(url)
+                .hash(UrlShortener.shortenUrl(url))
+                .expiredAt(LocalDateTime.now().plusHours(1))
+                .build();
+
+        savedUrl.assignSession(session);
+        urlRepository.save(savedUrl);
+
+        // when
+        ShortenUrlsResponse urls = urlService.findAllBySessionUuid(uuid);
+
+        // then
+        assertThat(urls.getUrls().size()).isEqualTo(1);
+    }
 
 }

--- a/src/test/java/com/example/urlshortener/domain/url/application/UrlServiceTest.java
+++ b/src/test/java/com/example/urlshortener/domain/url/application/UrlServiceTest.java
@@ -31,18 +31,27 @@ class UrlServiceTest extends IntegrationTest {
     @Autowired
     private MemberRepository memberRepository;
 
+    @Autowired
+    private SessionRepository sessionRepository;
 
     @BeforeEach
     public void setUp() throws Exception {
         urlRepository.deleteAllInBatch();
         memberRepository.deleteAllInBatch();
+        sessionRepository.deleteAllInBatch();
     }
 
     @Test
     @DisplayName("full url을 가지고 hash값을 생성하고 저장한다.")
     void shortenUrl() {
         // given
+        Session session = new Session();
+        String uuid = UUID.randomUUID().toString();
+        session.assignUUID(uuid);
+        sessionRepository.save(session);
+
         ShortenUrlRequest request = ShortenUrlRequest.builder()
+                .sessionUuid(uuid)
                 .fullUrl("www.test.com")
                 .build();
 

--- a/src/test/java/com/example/urlshortener/domain/url/dao/UrlRepositoryTest.java
+++ b/src/test/java/com/example/urlshortener/domain/url/dao/UrlRepositoryTest.java
@@ -1,5 +1,7 @@
 package com.example.urlshortener.domain.url.dao;
 
+import com.example.urlshortener.domain.auth.dao.SessionRepository;
+import com.example.urlshortener.domain.auth.domain.Session;
 import com.example.urlshortener.domain.member.dao.MemberRepository;
 import com.example.urlshortener.domain.member.domain.Member;
 import com.example.urlshortener.domain.member.domain.MemberBuilder;
@@ -11,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -21,6 +24,9 @@ class UrlRepositoryTest extends RepositoryTest {
 
     @Autowired
     private MemberRepository memberRepository;
+
+    @Autowired
+    private SessionRepository sessionRepository;
 
     @Test
     @DisplayName("Hash 값으로 URL을 조회한다.")
@@ -70,6 +76,27 @@ class UrlRepositoryTest extends RepositoryTest {
 
         // then
         assertThat(urls.size()).isEqualTo(2);
+
+    }
+
+    @Test
+    @DisplayName("session uuid로 URL을 조회한다.")
+    void findAllBySessionUuid() {
+        // given
+        Session session = new Session();
+        String uuid = UUID.randomUUID().toString();
+        session.assignUUID(uuid);
+        sessionRepository.save(session);
+
+        Url url = Url.of("www.test.com", "hash");
+        url.assignSession(session);
+        urlRepository.save(url);
+
+        // when
+        List<Url> urls = urlRepository.findAllBySessionUuid(uuid);
+
+        // then
+        assertThat(urls.size()).isEqualTo(1);
 
     }
 

--- a/src/test/java/com/example/urlshortener/domain/url/domain/UrlTest.java
+++ b/src/test/java/com/example/urlshortener/domain/url/domain/UrlTest.java
@@ -1,5 +1,6 @@
 package com.example.urlshortener.domain.url.domain;
 
+import com.example.urlshortener.domain.auth.domain.Session;
 import com.example.urlshortener.domain.url.exception.InvalidProlongExpirationPeriodException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -75,6 +76,22 @@ class UrlTest {
 
     }
 
+    @Test
+    @DisplayName("")
+    void assignSession(){
+        // give
+        Url url = Url.builder()
+                .build();
+
+        Session expected = new Session();
+
+        // when
+        url.assignSession(expected);
+
+        // then
+        Session actual = url.getSession();
+        assertThat(actual).isEqualTo(expected);
+    }
 
     private static Stream<Arguments> provideLocalDateTimesForCheckExpired() {
         return Stream.of(


### PR DESCRIPTION
## 구현 기능
 - 비로그인인 경우, 비로그인 사용자의 브라우저를 식별할 수 있는 session(비로그식 식별자)을 발급한다.
 - 비로그인인 경우, 비로그인식 식별자를 통해 url 저장된 url을 조회할 수 있다.
## 학습한 내용
- repository test에서 acceptance test나 service test에서 사용한 texture를 사용하면 문제가 생길 수 있음
  -  acceptance / service test의 경우 통합 테스트이고, BeforeEach를 통해서 각 테스트 케이스 시작전에 db를 비우는 작업을 하지만 마지막 테스트 케이스가 실행되고 나서 db를 비우지 않음, 이 상태로 repository test를 실행하면 db에 데이터가 남아있을 수 있고 그에 따라 unique 제약 조건에 걸린다거나 하는 이슈가 발생할 수 있음

## Close
- close #12 
